### PR TITLE
Adding functionality for changing the offset of caption lines

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -63,3 +63,18 @@ body.removeCaptions #removeCaptions > div {
 #offsetCaptions > span:hover {
     background-color: aliceblue;
     }
+    
+#lineCaptions {
+    display: flex;
+    justify-content: space-evenly;
+    user-select: none;
+    }
+#lineCaptions > span {
+    cursor: pointer;
+    padding: 1em 0.75em;
+    }
+#lineCaptions > span:hover {
+    background-color: aliceblue;
+    }
+    
+    

--- a/src/popup.html
+++ b/src/popup.html
@@ -24,6 +24,15 @@
             <span data-offset="1">&plus;1</span>
             <span data-offset="10">&plus;10</span>
         </div>
+        <div class="menu-item">Line offset:
+        </div>
+        <div id="lineCaptions">
+            <span line-offset="-2">&minus;2</span>
+            <span line-offset="-1">&minus;1</span>
+            <span line-offset="1">&plus;1</span>
+            <span line-offset="2">&plus;2</span>
+        </div>
+        
     </div>
 </div>
 <script src="popup.js"></script>

--- a/src/popup.js
+++ b/src/popup.js
@@ -30,6 +30,7 @@
         if ( track === null ) { return; }
         timeDelta += parseFloat(track.getAttribute('data-vtt-offset') || '0');
         track.setAttribute('data-vtt-offset', timeDelta);
+        track.setAttribute('lineOffset',-1)
     };
 
     const timeSetContentScript = function() {
@@ -37,7 +38,22 @@
         const track = document.querySelector('video > track[label="CCaptioner"][data-vtt]');
         if ( track === null ) { return; }
         track.setAttribute('data-vtt-offset', timeDelta);
+        track.setAttribute('lineOffset',-1)
     };
+    
+    const lineShiftContentScript = function() {
+        let lineDelta = parseFloat('$0') || 0;
+        const track = document.querySelector('video > track[label="CCaptioner"][data-vtt]');
+        if ( track === null ) { return; }
+        if (!track.hasAttribute('lineOffset')) {track.setAttribute('lineOffset',-1)} 
+        lineDelta += parseFloat(track.getAttribute('lineOffset') || '0')
+        track.setAttribute('lineOffset', lineDelta)
+
+        for (const cue of track.track.cues) {
+            cue.line = lineDelta
+        }
+    };
+    
 
     const makeContentScript = function(fn, ...args) {
         let code = [ '(', fn.toString(), ')();', ].join('\n');
@@ -108,6 +124,21 @@
         }
     );
 
+    document.querySelector('#lineCaptions').addEventListener(
+        'click',
+        ev => {
+            const button = ev.target;
+            if (button.hasAttribute('line-offset') === false) {return; }
+            injectScriptCode(
+                makeContentScript(
+                    lineShiftContentScript,
+                    button.getAttribute('line-offset')
+                )
+            );
+            
+        
+        }
+    );
 
     document.querySelector('#reset0Sec').addEventListener(
         'click',


### PR DESCRIPTION
I added basic functionality that allows changing the vertical location of the captions. Press -1 or -2 to move captions up 1 or 2 lines, and +1 or +2 to move them down. It appears to work in my tests. Currently, the cues reset to their default locations when changing the time offset. This is the first time I've ever tried to write javascript (besides freecodecamp tutorials), so it's possible I've done something dumb.

